### PR TITLE
Fix: ValueError in get_user_articles function

### DIFF
--- a/Recommendations_with_IBM.ipynb
+++ b/Recommendations_with_IBM.ipynb
@@ -1066,7 +1066,7 @@
     "    '''\n",
     "    # Your code here\n",
     "    article_ids = user_item.loc[user_id]\n",
-    "    article_ids =  [str(aid) for aid in article_ids[article_ids == 1].index]\n",
+    "    article_ids =  [str(aid) for aid in article_ids[article_ids == 1].title.index]\n",
     "    \n",
     "    article_names = get_article_names(article_ids)\n",
     "    \n",


### PR DESCRIPTION
The function created a tuple of article_ids instead of a float or integer value. This caused an issue in the get_article_names since it only takes integer and float values to process the operation. 